### PR TITLE
Add minimal Flutter login/profile example

### DIFF
--- a/flutter_login_profile/README.md
+++ b/flutter_login_profile/README.md
@@ -1,0 +1,8 @@
+# Flutter Login Profile App
+
+Dies ist ein sehr einfaches Flutter-Beispiel mit zwei Seiten:
+
+1. **Login** – beinhaltet Eingabefelder für Benutzername/E-Mail und Passwort sowie einen Login-Button.
+2. **Profil** – zeigt einfache Profildaten wie Name und Alter.
+
+Das Projekt enthält nur die wichtigsten Dateien ( `pubspec.yaml` und `lib/main.dart` ) und dient als minimaler Ausgangspunkt. Zum Ausführen des Projekts muss Flutter installiert sein. Anschließend kann es wie gewohnt mit `flutter run` gestartet werden.

--- a/flutter_login_profile/lib/main.dart
+++ b/flutter_login_profile/lib/main.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Login Demo',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const LoginScreen(),
+    );
+  }
+}
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({Key? key}) : super(key: key);
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(
+                labelText: 'Benutzername / E-Mail',
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Passwort'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ProfileScreen(
+                      username: _usernameController.text,
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class ProfileScreen extends StatelessWidget {
+  final String username;
+
+  const ProfileScreen({Key? key, required this.username}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profil')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Name: $username'),
+            const SizedBox(height: 8),
+            const Text('Alter: 25'),
+            const SizedBox(height: 8),
+            const Text('Weitere Informationen...'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_login_profile/pubspec.yaml
+++ b/flutter_login_profile/pubspec.yaml
@@ -1,0 +1,19 @@
+name: flutter_login_profile
+description: A simple Flutter app with login and profile screens.
+publish_to: 'none'
+version: 1.0.0
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add `flutter_login_profile` example project
  - pubspec
  - main dart source
  - simple readme describing the project

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884c935dd248328bfcae836d540de59